### PR TITLE
Run grobid with docker instead of via command line

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,13 +18,13 @@ pip install git+https://github.com/titipata/scipdf_parser
 
 Run the GROBID using the given bash script before parsing PDF. 
 
-**NOTE**: the recommended way to [run grobid is via docker](https://grobid.readthedocs.io/en/latest/Grobid-docker/), so make sure it's running on your machine. Update the version to the [latest version](https://github.com/kermitt2/grobid/releases).
+**NOTE**: the recommended way to [run grobid is via docker](https://grobid.readthedocs.io/en/latest/Grobid-docker/), so make sure it's running on your machine. Update the script so that you are using [latest version](https://github.com/kermitt2/grobid/releases). Generally, at every version there are substantial improvements. 
 
 ```bash
 bash serve_grobid.sh
 ```
 
-This script will download GROBID and run the service at default port 8070 (see more [here](https://grobid.readthedocs.io/en/latest/Grobid-service/)).
+This script will run GROBID at default port 8070 (see more [here](https://grobid.readthedocs.io/en/latest/Grobid-service/)).
 To parse a PDF provided in `example_data` folder or direct URL, use the following function:
 
 ```python

--- a/README.md
+++ b/README.md
@@ -16,7 +16,9 @@ pip install git+https://github.com/titipata/scipdf_parser
 
 ## Usage
 
-Run the GROBID using the given bash script before parsing PDF
+Run the GROBID using the given bash script before parsing PDF. 
+
+**NOTE**: the recommended way to [run grobid is via docker](https://grobid.readthedocs.io/en/latest/Grobid-docker/), so make sure it's running on your machine. Update the version to the [latest version](https://github.com/kermitt2/grobid/releases).
 
 ```bash
 bash serve_grobid.sh

--- a/serve_grobid.sh
+++ b/serve_grobid.sh
@@ -1,5 +1,16 @@
 #!/bin/bash
+# Recommended way to run Grobid is to have docker installed. See details here: https://grobid.readthedocs.io/en/latest/Grobid-docker/
 
-# Recommended way to run Grobid is Docker, https://grobid.readthedocs.io/en/latest/Grobid-docker/
+if ! command -v docker &> /dev/null; then
+    echo "Error: Docker is not installed. Please install Docker before running Grobid."
+    exit 1
+fi
 
-docker run --rm --gpus all --init --ulimit core=0 -p 8070:8070 grobid/grobid:0.7.3
+
+machine_arch=$(uname -m)
+
+if [ "$machine_arch" == "armv7l" ] || [ "$machine_arch" == "aarch64" ]; then
+    docker run --rm --gpus all --init --ulimit core=0 -p 8070:8070 grobid/grobid:0.7.3-arm
+else
+    docker run --rm --gpus all --init --ulimit core=0 -p 8070:8070 grobid/grobid:0.7.3
+fi

--- a/serve_grobid.sh
+++ b/serve_grobid.sh
@@ -2,4 +2,4 @@
 
 # Recommended way to run Grobid is Docker, https://grobid.readthedocs.io/en/latest/Grobid-docker/
 
-docker run --rm --gpus all --init --ulimit core=0 -p 8080:8070 grobid/grobid:0.7.3
+docker run --rm --gpus all --init --ulimit core=0 -p 8070:8070 grobid/grobid:0.7.3

--- a/serve_grobid.sh
+++ b/serve_grobid.sh
@@ -1,14 +1,5 @@
 #!/bin/bash
 
-# download GROBID if directory does not exist
-declare -r GROBID_VERSION="0.6.2" # or change to current stable version
+# Recommended way to run Grobid is Docker, https://grobid.readthedocs.io/en/latest/Grobid-docker/
 
-if [ ! -d grobid-${GROBID_VERSION} ]; then
-  wget https://github.com/kermitt2/grobid/archive/${GROBID_VERSION}.zip
-  unzip "${GROBID_VERSION}.zip"
-  rm "${GROBID_VERSION}.zip"
-fi
-
-# run GROBID
-cd grobid-${GROBID_VERSION} || exit
-./gradlew run
+docker run --rm --gpus all --init --ulimit core=0 -p 8080:8070 grobid/grobid:0.7.3


### PR DESCRIPTION
Running Grobid with Docker solves various issues of compatibility, firstly the support for windows. Then it solves also issues with different JDK and various configurations. 